### PR TITLE
Update canvas size calculation and add demo for canvas resize

### DIFF
--- a/__test__/MouseEventManagerScene.ts
+++ b/__test__/MouseEventManagerScene.ts
@@ -30,6 +30,7 @@ export class MouseEventManagerScene {
     this.canvas.style.width = `${MouseEventManagerScene.W}px`;
     this.canvas.style.height = `${MouseEventManagerScene.H}px`;
 
+    document.body.appendChild(this.canvas);
     //マウスイベントの取得開始
     this.manager = new MouseEventManager(this.scene, this.camera, this.canvas);
   }

--- a/demoSrc/demo_simple_resize.js
+++ b/demoSrc/demo_simple_resize.js
@@ -1,4 +1,3 @@
-import { contain } from "three/src/extras/TextureUtils.js";
 import {
   CheckBoxMesh,
   CheckBoxSprite,

--- a/demoSrc/demo_simple_resize.js
+++ b/demoSrc/demo_simple_resize.js
@@ -7,6 +7,7 @@ import {
   RadioButtonManager,
   RadioButtonMesh,
   StateMaterialSet,
+  resizeCanvasStyle,
 } from "../esm/index.js";
 import {
   AmbientLight,
@@ -45,21 +46,10 @@ const onDomContentsLoaded = () => {
   containerDiv.style.alignItems = "center";
   containerDiv.style.justifyContent = "center";
 
-  const aspectRatio = W / H;
   canvas.style.maxWidth = "100%";
   canvas.style.maxHeight = "100%";
-
   const resizeCanvas = () => {
-    const containerWidth = containerDiv.clientWidth;
-    const containerHeight = containerDiv.clientHeight;
-
-    if (containerWidth / containerHeight > aspectRatio) {
-      canvas.style.width = `${containerHeight * aspectRatio}px`;
-      canvas.style.height = `${containerHeight}px`;
-    } else {
-      canvas.style.width = `${containerWidth}px`;
-      canvas.style.height = `${containerWidth / aspectRatio}px`;
-    }
+    resizeCanvasStyle(containerDiv, canvas, W, H);
   };
 
   resizeCanvas();

--- a/demoSrc/demo_simple_resize.js
+++ b/demoSrc/demo_simple_resize.js
@@ -1,0 +1,229 @@
+import { contain } from "three/src/extras/TextureUtils.js";
+import {
+  CheckBoxMesh,
+  CheckBoxSprite,
+  ClickableMesh,
+  ClickableSprite,
+  MouseEventManager,
+  RadioButtonManager,
+  RadioButtonMesh,
+  StateMaterialSet,
+} from "../esm/index.js";
+import {
+  AmbientLight,
+  BoxGeometry,
+  Color,
+  MeshBasicMaterial,
+  PerspectiveCamera,
+  Scene,
+  SpriteMaterial,
+  TextureLoader,
+  WebGLRenderer,
+  REVISION,
+} from "three";
+
+const W = 1280;
+const H = 900;
+let renderer;
+let scene;
+let camera;
+
+const onDomContentsLoaded = () => {
+  console.log(`Three.js r${REVISION}`);
+
+  const canvas = document.getElementById("webgl-canvas");
+  canvas.parentElement.removeChild(canvas);
+
+  const containerDiv = document.createElement("div");
+  document.body.appendChild(containerDiv);
+  containerDiv.appendChild(canvas);
+
+  document.body.style.overflow = "hidden";
+
+  containerDiv.style.width = "100vw";
+  containerDiv.style.height = "100vh";
+  containerDiv.style.display = "flex";
+  containerDiv.style.alignItems = "center";
+  containerDiv.style.justifyContent = "center";
+
+  const aspectRatio = W / H;
+  canvas.style.maxWidth = "100%";
+  canvas.style.maxHeight = "100%";
+
+  const resizeCanvas = () => {
+    const containerWidth = containerDiv.clientWidth;
+    const containerHeight = containerDiv.clientHeight;
+
+    if (containerWidth / containerHeight > aspectRatio) {
+      canvas.style.width = `${containerHeight * aspectRatio}px`;
+      canvas.style.height = `${containerHeight}px`;
+    } else {
+      canvas.style.width = `${containerWidth}px`;
+      canvas.style.height = `${containerWidth / aspectRatio}px`;
+    }
+  };
+
+  resizeCanvas();
+  window.addEventListener("resize", resizeCanvas);
+
+  // シーンを作成
+  scene = new Scene();
+  camera = new PerspectiveCamera(45, W / H, 1, 400);
+  camera.position.set(0, 0, 100);
+  scene.add(camera);
+
+  const renderOption = {
+    canvas: document.getElementById("webgl-canvas"),
+    antialias: true,
+  };
+  renderer = new WebGLRenderer(renderOption);
+  renderer.setClearColor(new Color(0x000000));
+  renderer.setSize(W, H, false);
+
+  //平行光源オブジェクト(light)の設定
+  const ambientLight = new AmbientLight(0xffffff, 1.0);
+  scene.add(ambientLight);
+
+  //マウスイベントの取得開始
+  const manager = new MouseEventManager(scene, camera, renderer.domElement);
+
+  testButton();
+  testCheckbox();
+  testSprite();
+  testSelectableSprite();
+  testRadio();
+
+  render();
+};
+
+/**
+ * Mesh用のマテリアルセットを新規に取得する。
+ * @returns {StateMaterialSet}
+ */
+const getMaterialSet = () => {
+  return new StateMaterialSet({
+    normal: getMeshMaterial(0.6),
+    over: getMeshMaterial(0.8),
+    down: getMeshMaterial(1.0),
+    normalSelect: getMeshMaterial(0.6, 0xffff00),
+    overSelect: getMeshMaterial(0.8, 0xffff00),
+    downSelect: getMeshMaterial(1.0, 0xffff00),
+  });
+};
+
+const getMeshMaterial = (opacity, color) => {
+  if (color == null) color = 0xffffff;
+  return new MeshBasicMaterial({
+    color: color,
+    opacity: opacity,
+    transparent: true,
+  });
+};
+
+/**
+ * スプライト用のマテリアルセットを新規に生成する。
+ */
+const getSpriteMaterialSet = () => {
+  return new StateMaterialSet({
+    normal: getSpriteMaterial("./btn045_01.png", 1.0),
+    over: getSpriteMaterial("./btn045_02.png", 1.0),
+    down: getSpriteMaterial("./btn045_03.png", 1.0),
+    normalSelect: getSpriteMaterial("./btn045_01.png", 0.5),
+    overSelect: getSpriteMaterial("./btn045_02.png", 0.5),
+    downSelect: getSpriteMaterial("./btn045_03.png", 0.5),
+  });
+};
+
+/**
+ * スプライト用マテリアルを生成する
+ * @param img マップ画像URL
+ * @param opacity 透過度
+ * @param color カラー
+ * @returns {SpriteMaterial}
+ */
+const getSpriteMaterial = (img, opacity, color) => {
+  if (color == null) color = 0xffffff;
+  return new SpriteMaterial({
+    map: new TextureLoader().load(img),
+    color: color,
+    opacity: opacity,
+    transparent: true,
+  });
+};
+
+const testButton = () => {
+  const geometry = new BoxGeometry(3, 3, 3);
+  const clickable = new ClickableMesh({
+    geo: geometry,
+    material: getMaterialSet(),
+  });
+
+  clickable.position.set(-10, 20, 0);
+  scene.add(clickable);
+};
+
+const testCheckbox = () => {
+  const geometry = new BoxGeometry(3, 3, 3);
+  const clickable = new CheckBoxMesh({
+    geo: geometry,
+    material: getMaterialSet(),
+  });
+
+  clickable.position.set(0, 20, 0);
+  scene.add(clickable);
+};
+
+const testSprite = () => {
+  const clickable = new ClickableSprite(getSpriteMaterialSet());
+  alignSprite(clickable, 10);
+};
+
+const testSelectableSprite = () => {
+  const selectable = new CheckBoxSprite(getSpriteMaterialSet());
+  alignSprite(selectable, 20);
+};
+
+const alignSprite = (sprite, x) => {
+  sprite.position.set(x, 20, 0);
+  const scale = 4.0;
+  sprite.scale.set(scale, scale, scale);
+  scene.add(sprite);
+};
+
+const testRadio = () => {
+  const geometry = new BoxGeometry(3, 3, 3);
+
+  const initButton = (x, buttonValue) => {
+    const button = new RadioButtonMesh({
+      geo: geometry,
+      material: getMaterialSet(),
+    });
+    button.position.set(x, -10, 0);
+    button.interactionHandler.value = buttonValue;
+    scene.add(button);
+    return button;
+  };
+
+  const manager = new RadioButtonManager();
+
+  manager.addButton(
+    initButton(-10, "button01"),
+    initButton(0, Math.PI),
+    initButton(10, { value01: 1, value02: 2 }),
+  );
+  manager.addButton(initButton(20, undefined));
+
+  manager.on("select", (e) => {
+    console.log(e.interactionHandler.value);
+  });
+};
+
+const render = () => {
+  renderer.render(scene, camera);
+  requestAnimationFrame(render);
+};
+
+/**
+ * DOMContentLoaded以降に初期化処理を実行する
+ */
+window.onload = onDomContentsLoaded;

--- a/src/ViewPortUtil.ts
+++ b/src/ViewPortUtil.ts
@@ -22,24 +22,11 @@ export class ViewPortUtil {
    * @private
    */
   private static getCanvasHeight(canvas: HTMLCanvasElement): number {
-    return this.getCanvasSize(canvas, "height");
+    return canvas.clientHeight;
   }
 
   private static getCanvasWidth(canvas: HTMLCanvasElement): number {
-    return this.getCanvasSize(canvas, "width");
-  }
-
-  private static getCanvasSize(
-    canvas: HTMLCanvasElement,
-    propName: "width" | "height",
-  ): number {
-    const style = canvas.style;
-    if (style.width && style.height) {
-      return parseInt(style[propName]);
-    } else if (window.devicePixelRatio != null) {
-      return canvas[propName] / window.devicePixelRatio;
-    }
-    return canvas[propName];
+    return canvas.clientWidth;
   }
 
   /**

--- a/src/convertToInteractiveView.ts
+++ b/src/convertToInteractiveView.ts
@@ -1,3 +1,8 @@
+/**
+ * すでに存在するMeshをClickableMeshに変換するユーティリティ関数。
+ * gltfなどで読み込んだMeshをClickableMeshに変換する際に使用する。
+ */
+
 import { Mesh } from "three";
 import { CheckBoxMesh, ClickableMesh, RadioButtonMesh } from "./view/index.js";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from "./ThreeMouseEvent.js";
 
 export * from "./ViewPortUtil.js";
 export * from "./convertToInteractiveView.js";
+export * from "./resizeCanvasStyle.js";

--- a/src/resizeCanvasStyle.ts
+++ b/src/resizeCanvasStyle.ts
@@ -1,0 +1,28 @@
+/**
+ * アスペクト比を保ちつつ、canvas要素のスタイルをリサイズする。
+ * canvasの表示サイズのみを変更し、描画サイズは変更しない。
+ * そのため、描画負荷は変わらないので注意。画質の劣化や描画負荷が過剰な場合は、解像度を変更する方法を検討すること。
+ *
+ * @param container
+ * @param canvas
+ * @param canvasWidth
+ * @param canvasHeight
+ */
+export function resizeCanvasStyle(
+  container: HTMLElement,
+  canvas: HTMLCanvasElement,
+  canvasWidth: number,
+  canvasHeight: number,
+): void {
+  const containerWidth = container.clientWidth;
+  const containerHeight = container.clientHeight;
+  const aspectRatio = canvasWidth / canvasHeight;
+
+  if (containerWidth / containerHeight > aspectRatio) {
+    canvas.style.width = `${containerHeight * aspectRatio}px`;
+    canvas.style.height = `${containerHeight}px`;
+  } else {
+    canvas.style.width = `${containerWidth}px`;
+    canvas.style.height = `${containerWidth / aspectRatio}px`;
+  }
+}


### PR DESCRIPTION
This pull request includes several changes related to canvas resizing and utility functions.

The `ViewPortUtil` class has been updated to use the `clientWidth` and `clientHeight` properties of the canvas instead of the `style` properties.

Additionally, a new utility function `resizeCanvasStyle` has been added to resize the canvas while maintaining its aspect ratio. The demo code has been updated to demonstrate the canvas resize functionality.