### PR TITLE
Move browser configuration to instances array in Vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,13 @@ export default defineConfig({
   test: {
     browser: {
       enabled: true,
-      name: "chrome",
       provider: "webdriverio",
       headless: true,
+      instances: [
+        {
+          browser: "chrome",
+        },
+      ],
     },
     poolOptions: {
       threads: {


### PR DESCRIPTION
Refactor the Vitest configuration to move the browser settings into an instances array for better organization and flexibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated browser testing configuration to support specifying multiple browser instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->