### PR TITLE
refactor: separate InteractionHandlerConstructor interface into standalone file

### DIFF
--- a/src/view/InteractionHandlerConstructor.ts
+++ b/src/view/InteractionHandlerConstructor.ts
@@ -1,0 +1,24 @@
+import type {
+  ButtonInteractionHandler,
+  ButtonInteractionHandlerParameters,
+} from "../index.js";
+
+/**
+ * Constructor interface for interaction handler classes.
+ *
+ * @description
+ * This interface defines the constructor signature for interaction handler classes
+ * that extend ButtonInteractionHandler. It ensures type safety when passing
+ * handler constructors to interactive view objects (mesh, sprite, group).
+ *
+ * @template InteractionHandler - The specific interaction handler type
+ * @template Value - Type of arbitrary data associated with the interactive object
+ *
+ * @public
+ */
+export interface InteractionHandlerConstructor<
+  InteractionHandler extends ButtonInteractionHandler<Value>,
+  Value,
+> {
+  new (param: ButtonInteractionHandlerParameters<Value>): InteractionHandler;
+}

--- a/src/view/InteractiveMesh.ts
+++ b/src/view/InteractiveMesh.ts
@@ -24,10 +24,10 @@ import {
   ButtonInteractionHandler,
   CheckBoxInteractionHandler,
   type IClickableObject3D,
-  type InteractionHandlerConstructor,
   RadioButtonInteractionHandler,
   type StateMaterialSet,
 } from "../index.js";
+import type { InteractionHandlerConstructor } from "./InteractionHandlerConstructor.js";
 
 /**
  * Configuration parameters for creating interactive mesh objects.

--- a/src/view/InteractiveSprite.ts
+++ b/src/view/InteractiveSprite.ts
@@ -1,19 +1,12 @@
 import { Sprite } from "three";
 import {
   ButtonInteractionHandler,
-  type ButtonInteractionHandlerParameters,
   CheckBoxInteractionHandler,
   type IClickableObject3D,
   RadioButtonInteractionHandler,
   type StateMaterialSet,
 } from "../index.js";
-
-export interface InteractionHandlerConstructor<
-  InteractionHandler extends ButtonInteractionHandler<Value>,
-  Value,
-> {
-  new (param: ButtonInteractionHandlerParameters<Value>): InteractionHandler;
-}
+import type { InteractionHandlerConstructor } from "./InteractionHandlerConstructor.js";
 
 class InteractiveSprite<Value, Handler extends ButtonInteractionHandler<Value>>
   extends Sprite


### PR DESCRIPTION
## Summary
- Extract `InteractionHandlerConstructor` interface from InteractiveSprite.ts into a dedicated file
- Move interface to `src/view/InteractionHandlerConstructor.ts` for better code organization
- Update imports in InteractiveMesh.ts and InteractiveSprite.ts to use the new standalone interface
- Remove unused `ButtonInteractionHandlerParameters` import from InteractiveSprite.ts

## Benefits
- Improves code organization by separating shared interfaces
- Eliminates duplication of the interface definition
- Makes the interface more discoverable and reusable
- Better separation of concerns in the view module

## Test plan
- [x] TypeScript compilation passes
- [x] All existing tests pass (58/58)
- [x] Biome linting and formatting checks pass
- [x] No breaking changes to public API

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized the definition of the interaction handler constructor interface for improved consistency and maintainability.
  * Updated imports in interactive view components to use the shared interface definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->