### PR TITLE
fix: correct JSDoc for CheckBoxInteractionHandler selection setter

### DIFF
--- a/__test__/CheckBoxSprite.spec.ts
+++ b/__test__/CheckBoxSprite.spec.ts
@@ -1,4 +1,4 @@
-import { SpriteMaterial } from "three";
+import type { SpriteMaterial } from "three";
 import { describe, expect, test } from "vitest";
 import { CheckBoxSprite } from "../src/index.js";
 import { getSpriteMaterialSet } from "./Materials.js";

--- a/src/interactionHandler/CheckBoxInteractionHandler.ts
+++ b/src/interactionHandler/CheckBoxInteractionHandler.ts
@@ -125,7 +125,7 @@ export class CheckBoxInteractionHandler<
    * @remarks
    * - **No events emitted** (prevents infinite loops in RadioButtonManager)
    * - **Respects disabled/frozen states** via checkActivity() validation
-   * - **Preserves current visual state** (hover, press) for consistent UX
+   * - **Clears press state** (resets to "up") to prevent unintended click on release; hover state is preserved for consistent UX
    * - **Performance optimized** (skips redundant updateMaterial() calls for same-value settings)
    *
    * @example


### PR DESCRIPTION
## Summary
- Fix JSDoc inconsistency in CheckBoxInteractionHandler selection setter
- Correct Biome linter warning for import type usage

## Changes
- Update JSDoc description to accurately reflect that press state is cleared (not preserved) during programmatic selection changes
- Change `import { SpriteMaterial }` to `import type { SpriteMaterial }` in CheckBoxSprite.spec.ts for better TypeScript optimization

## Details
The previous JSDoc stated "Preserves current visual state (hover, press)" but the actual implementation clears the press state with `this._isPress = false`. This correction aligns documentation with the actual behavior to prevent unintended click events after programmatic selection changes.

🤖 Generated with [Claude Code](https://claude.ai/code)