### PR TITLE
refactor(demo): improve touch-action specification for canvas elements

### DIFF
--- a/demoSrc/demo_simple.js
+++ b/demoSrc/demo_simple.js
@@ -46,8 +46,7 @@ const onDomContentsLoaded = () => {
   renderer.setPixelRatio(window.devicePixelRatio);
   canvas.style.width = `${W}px`;
   canvas.style.height = `${H}px`;
-
-  document.body.style = "touch-action: none;";
+  canvas.style.touchAction = "none";
 
   //平行光源オブジェクト(light)の設定
   const ambientLight = new AmbientLight(0xffffff, 1.0);

--- a/demoSrc/demo_simple_resize.js
+++ b/demoSrc/demo_simple_resize.js
@@ -48,6 +48,7 @@ const onDomContentsLoaded = () => {
 
   canvas.style.maxWidth = "100%";
   canvas.style.maxHeight = "100%";
+  canvas.style.touchAction = "none";
   const resizeCanvas = () => {
     resizeCanvasStyle(containerDiv, canvas, W, H);
   };

--- a/demoSrc/demo_viewport.js
+++ b/demoSrc/demo_viewport.js
@@ -70,6 +70,7 @@ class SceneSet {
 const onDomContentsLoaded = () => {
   // シーンを作成
   const canvas = document.getElementById("webgl-canvas");
+  canvas.style.touchAction = "none";
   const renderOption = {
     canvas,
   };


### PR DESCRIPTION
## Summary
Improves touch gesture handling across all demo pages by applying `touch-action: none` specifically to canvas elements rather than document body, providing better user experience and more appropriate responsibility boundaries.

## Motivation
Touch gesture prevention was previously applied to entire document body in demo_simple.js, which restricted normal page scrolling unnecessarily. Mobile users should be able to scroll and interact with page elements outside the 3D canvas area while preventing touch gestures only within the WebGL interaction zones.

## Out of Scope
- **Three.js library core functionality** - Changes limited to demo page implementations only
- **HTML template modifications** - Canvas elements unchanged, only CSS styling affected  
- **Mobile-specific optimizations** - Focus on touch gesture control, not mobile performance tuning
- **Cross-browser compatibility testing** - Standard CSS property with broad support

## Scope
### Target
- Canvas element styling in all three demo pages
- Touch gesture prevention specifically for 3D interaction areas
- Consistent touch-action implementation across demo pages

### Dependencies
- Existing canvas element initialization in each demo page
- Current CSS styling patterns for demo pages
- WebGL rendering setup remains unchanged

### Boundaries
- Changes limited to demoSrc/ directory only
- No modifications to core library functionality
- CSS styling changes only, no JavaScript logic alterations

## Review Guidance
### Focus Areas
- Consistency of `canvas.style.touchAction = "none"` placement across all demo files
- Verification that canvas elements receive touch-action styling after DOM creation
- Ensure no regression in existing demo page functionality

🤖 Generated with [Claude Code](https://claude.ai/code)