### PR TITLE
fix(multitouch): resolve touch pointer stuck visual states with pointercancel and pointerleave handling

### DIFF
--- a/__test__/MouseEventManager.dispose.spec.ts
+++ b/__test__/MouseEventManager.dispose.spec.ts
@@ -77,7 +77,7 @@ describe("MouseEventManager Dispose Functionality", () => {
   };
 
   /**
-   * Helper function to verify that pointer event listeners have been removed
+   * Helper function to verify that all five pointer event listeners have been removed
    */
   const expectPointerEventListenersRemoved = (
     removeEventListenerSpy: MockInstance,
@@ -112,8 +112,24 @@ describe("MouseEventManager Dispose Functionality", () => {
     );
     expect(
       removeEventListenerSpy,
-      "Should call removeEventListener 3 times",
-    ).toHaveBeenCalledTimes(3);
+      "Should remove pointercancel listener",
+    ).toHaveBeenCalledWith(
+      "pointercancel",
+      typedManager.onDocumentPointerCancel,
+      false,
+    );
+    expect(
+      removeEventListenerSpy,
+      "Should remove pointerleave listener",
+    ).toHaveBeenCalledWith(
+      "pointerleave",
+      typedManager.onDocumentPointerLeave,
+      false,
+    );
+    expect(
+      removeEventListenerSpy,
+      "Should call removeEventListener 5 times",
+    ).toHaveBeenCalledTimes(5);
   };
 
   /**
@@ -140,7 +156,7 @@ describe("MouseEventManager Dispose Functionality", () => {
    * DOM Event Listener Management Tests
    */
   describe("DOM Event Listener Management", () => {
-    test("should remove all three pointer event listeners after dispose", () => {
+    test("should remove all five pointer event listeners after dispose", () => {
       const { managerScene } = createTestEnvironment();
 
       // Setup spies to monitor removeEventListener calls
@@ -467,7 +483,7 @@ describe("MouseEventManager Dispose Functionality", () => {
       expect(
         removeEventListenerSpy,
         "All event listeners should be removed",
-      ).toHaveBeenCalledTimes(3);
+      ).toHaveBeenCalledTimes(5);
       expect(
         rafTickerOffSpy,
         "RAF ticker subscription should be removed",

--- a/__test__/MouseEventManager.multi-touch.spec.ts
+++ b/__test__/MouseEventManager.multi-touch.spec.ts
@@ -576,5 +576,25 @@ describe("MouseEventManager Multi-touch Infrastructure", () => {
       // Should only have one out event from the cancel
       expect(outEvents.filter((e) => e.pointerId === pointerId).length).toBe(1);
     });
+
+    it("should not emit click when a pressed pointer is canceled", () => {
+      const { managerScene, multiFaceMesh, halfW, halfH } =
+        createTestEnvironment();
+      const pointerId = 7;
+
+      const clicks: number[] = [];
+      multiFaceMesh.interactionHandler.on("click", (e) =>
+        clicks.push(e.pointerId),
+      );
+
+      // Over + down on the object
+      managerScene.dispatchMouseEvent("pointermove", halfW, halfH, pointerId);
+      managerScene.dispatchMouseEvent("pointerdown", halfW, halfH, pointerId);
+
+      // Cancel the pointer stream (no up)
+      managerScene.dispatchMouseEvent("pointercancel", halfW, halfH, pointerId);
+
+      expect(clicks.length).toBe(0);
+    });
   });
 });

--- a/__test__/MouseEventManager.multi-touch.spec.ts
+++ b/__test__/MouseEventManager.multi-touch.spec.ts
@@ -315,10 +315,11 @@ describe("MouseEventManager Multi-touch Infrastructure", () => {
      *
      * TEMPORARILY SKIPPED: This test requires ButtonInteractionHandler multi-touch support
      *
-     * ## Current Limitation (Phase 2A/3A Scope)
-     * - ButtonInteractionHandler uses single `_isOver: boolean` state
-     * - Only first pointer generates "over" event, subsequent pointers blocked
+     * ## Current State (Phase 2A/3A with Touch Fixes)
      * - MouseEventManager correctly processes all pointers independently
+     * - Real-device touch pointer disappearance issues resolved with pointercancel/pointerleave
+     * - ButtonInteractionHandler still uses single `_isOver: boolean` state
+     * - Only first pointer generates "over" event, subsequent pointers blocked
      *
      * ## Required for Phase 2B/3B
      * - Convert ButtonInteractionHandler._isOver from boolean to Map<number, boolean>
@@ -462,6 +463,118 @@ describe("MouseEventManager Multi-touch Infrastructure", () => {
         // Guaranteed cleanup even if assertions fail
         checkTargetSpy.mockRestore();
       }
+    });
+  });
+
+  describe("Pointer Cancel and Leave Event Handling", () => {
+    it("should handle pointercancel events and clean up internal state", () => {
+      const { managerScene, multiFaceMesh, halfW, halfH } =
+        createTestEnvironment();
+      const pointerId1 = 1;
+      const pointerId2 = 2;
+
+      // biome-ignore lint/suspicious/noExplicitAny: Testing internal currentOver Map requires accessing private property
+      const currentOver = (managerScene.manager as any).currentOver as Map<
+        number,
+        IClickableObject3D<unknown>[]
+      >;
+
+      // Set up hover states for multiple pointers
+      managerScene.dispatchMouseEvent("pointermove", halfW, halfH, pointerId1);
+      managerScene.dispatchMouseEvent("pointermove", halfW, halfH, pointerId2);
+
+      expect(currentOver.get(pointerId1)).toContain(multiFaceMesh);
+      expect(currentOver.get(pointerId2)).toContain(multiFaceMesh);
+
+      // Track out events
+      const outEvents: Array<{ pointerId: number }> = [];
+      multiFaceMesh.interactionHandler.on("out", (e) => {
+        outEvents.push({ pointerId: e.pointerId });
+      });
+
+      // Cancel pointer1 - should clean up state and emit out event
+      managerScene.dispatchMouseEvent(
+        "pointercancel",
+        halfW,
+        halfH,
+        pointerId1,
+      );
+
+      expect(currentOver.has(pointerId1)).toBe(false);
+      expect(currentOver.has(pointerId2)).toBe(true);
+      expect(outEvents.some((e) => e.pointerId === pointerId1)).toBe(true);
+    });
+
+    it("should handle pointerleave events and clean up internal state", () => {
+      const { managerScene, multiFaceMesh, halfW, halfH } =
+        createTestEnvironment();
+      const pointerId1 = 1;
+      const pointerId2 = 2;
+
+      // biome-ignore lint/suspicious/noExplicitAny: Testing internal currentOver Map requires accessing private property
+      const currentOver = (managerScene.manager as any).currentOver as Map<
+        number,
+        IClickableObject3D<unknown>[]
+      >;
+
+      // Set up hover states for multiple pointers
+      managerScene.dispatchMouseEvent("pointermove", halfW, halfH, pointerId1);
+      managerScene.dispatchMouseEvent("pointermove", halfW, halfH, pointerId2);
+
+      expect(currentOver.get(pointerId1)).toContain(multiFaceMesh);
+      expect(currentOver.get(pointerId2)).toContain(multiFaceMesh);
+
+      // Track out events
+      const outEvents: Array<{ pointerId: number }> = [];
+      multiFaceMesh.interactionHandler.on("out", (e) => {
+        outEvents.push({ pointerId: e.pointerId });
+      });
+
+      // Leave with pointer1 - should clean up state and emit out event
+      managerScene.dispatchMouseEvent("pointerleave", halfW, halfH, pointerId1);
+
+      expect(currentOver.has(pointerId1)).toBe(false);
+      expect(currentOver.has(pointerId2)).toBe(true);
+      expect(outEvents.some((e) => e.pointerId === pointerId1)).toBe(true);
+    });
+
+    it("should handle pointercancel followed by pointerleave gracefully", () => {
+      const { managerScene, multiFaceMesh, halfW, halfH } =
+        createTestEnvironment();
+      const pointerId = 1;
+
+      // biome-ignore lint/suspicious/noExplicitAny: Testing internal currentOver Map requires accessing private property
+      const currentOver = (managerScene.manager as any).currentOver as Map<
+        number,
+        IClickableObject3D<unknown>[]
+      >;
+
+      // Set up hover state
+      managerScene.dispatchMouseEvent("pointermove", halfW, halfH, pointerId);
+      expect(currentOver.get(pointerId)).toContain(multiFaceMesh);
+
+      // Track out events
+      const outEvents: Array<{ pointerId: number }> = [];
+      multiFaceMesh.interactionHandler.on("out", (e) => {
+        outEvents.push({ pointerId: e.pointerId });
+      });
+
+      // Cancel first, then leave - should handle both gracefully without errors
+      managerScene.dispatchMouseEvent("pointercancel", halfW, halfH, pointerId);
+      expect(currentOver.has(pointerId)).toBe(false);
+
+      // Leave should be safe even after cancel already cleaned up
+      expect(() => {
+        managerScene.dispatchMouseEvent(
+          "pointerleave",
+          halfW,
+          halfH,
+          pointerId,
+        );
+      }).not.toThrow();
+
+      // Should only have one out event from the cancel
+      expect(outEvents.filter((e) => e.pointerId === pointerId).length).toBe(1);
     });
   });
 });

--- a/src/MouseEventManager.ts
+++ b/src/MouseEventManager.ts
@@ -454,10 +454,11 @@ export class MouseEventManager {
    * Performs the following operations:
    * 1. Retrieves all objects currently tracked as "over" for the specified pointer
    * 2. Sends "out" events to each tracked object via ButtonInteractionHandler
-   * 3. Removes the pointer from internal state tracking (currentOver Map)
+   * 3. Removes the pointer from internal state tracking (currentOver and hasThrottled Maps)
    *
    * This ensures visual states return to "normal" and prevents stuck hover states
-   * when pointers disappear without proper move/out event sequences.
+   * when pointers disappear without proper move/out event sequences. Also prevents
+   * stale throttling state that could affect future RAF tick processing.
    *
    * @motivation Real-device testing revealed touch pointers can disappear without
    *             standard event sequences, causing stuck visual states. This method
@@ -473,6 +474,7 @@ export class MouseEventManager {
       });
     }
     this.currentOver.delete(pointerId);
+    this.hasThrottled.delete(pointerId);
   }
 
   /**

--- a/src/MouseEventManager.ts
+++ b/src/MouseEventManager.ts
@@ -488,13 +488,13 @@ export class MouseEventManager {
    *
    * **Browser Event Sequence**: pointercancel → pointerout → pointerleave
    * **Mutual Exclusivity**: pointercancel and pointerup never both occur
-   * **Timing**: preventDefault() called to maintain consistent behavior
+   * **Timing**: preventDefault() called when cancelable to maintain consistent behavior
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/pointercancel_event
    * @see {@link cleanupPointerState} - Common cleanup implementation
    */
   protected onDocumentPointerCancel = (event: PointerEvent) => {
-    event.preventDefault();
+    if (event.cancelable) event.preventDefault();
     this.cleanupPointerState(event.pointerId);
   };
 

--- a/src/interactionHandler/ButtonInteractionHandler.ts
+++ b/src/interactionHandler/ButtonInteractionHandler.ts
@@ -418,7 +418,7 @@ export class ButtonInteractionHandler<Value> extends EventEmitter<
     if (wasPress) {
       this.onMouseClick();
 
-      const e = ThreeMouseEventUtil.generate("click", this);
+      const e = ThreeMouseEventUtil.generate("click", this, event.pointerId);
       this.emit(e.type, e);
     }
   }
@@ -497,7 +497,8 @@ export class ButtonInteractionHandler<Value> extends EventEmitter<
 
     if (!this.checkActivity()) return;
 
-    this.updateState(this._isOver ? "over" : "normal");
+    const newState = this._isOver ? "over" : "normal";
+    this.updateState(newState);
     this.emit(event.type, event);
   }
 


### PR DESCRIPTION
## Summary
Resolves critical real-device issue where touch interactions caused visual states to remain stuck in "over" mode after pointer disappearance without proper cleanup events.

## Motivation
Real-device testing revealed touch pointers can disappear without standard move/out event sequences, causing stuck visual states. This occurred when system interrupts touch interactions (scrolling, system gestures) or when browsers generate pointer events in unexpected sequences.

#### Technical Analysis
- `pointercancel` events fire when system interrupts pointer interactions
- `pointerleave` events provide reliable cleanup as they always fire last in event sequence  
- Browser-generated event sequences differ significantly between desktop and mobile devices
- Visual states remained stuck because pointer state cleanup was incomplete

#### Related Issue
Related to #579 - This PR addresses critical touch interaction bugs discovered during Phase 2A/3A implementation. The core multitouch infrastructure from #579 remains in progress.

## Out of Scope
- **Phase 2B/3B multitouch features** - Deferred to maintain focused scope on critical bug fix
- **Desktop pointer behavior changes** - Existing desktop functionality unchanged
- **ButtonInteractionHandler API expansion** - Current API sufficient for fix implementation
- **Performance optimizations** - Focus on correctness over optimization for this critical fix

## Scope
### Target
- MouseEventManager pointer event handling for cancel and leave scenarios
- Internal pointer state cleanup logic with shared implementation
- ButtonInteractionHandler click event pointerId propagation accuracy
- Test coverage for new pointer interruption scenarios

### Dependencies
- Existing pointer event infrastructure (extended, not replaced)
- Current multitouch state tracking with pointerId-based Map storage
- RAFTicker integration and dispose method cleanup requirements

### Boundaries
- Changes limited to pointer event management layer
- No modifications to Three.js raycasting or interaction detection logic
- Frontend demo cleanup limited to debug code removal
- Test updates focused on new event listener expectations

## Review Guidance
### Focus Areas
- Pointer state cleanup logic in `cleanupPointerState` method
- Event listener registration and disposal safety
- Test coverage completeness for pointer cancel and leave scenarios
- Code duplication elimination between cancel and leave handlers

#### Technical Verification Points
- **Event Sequence Safety**: `pointerleave` fires after `pointerup` without interfering with click events
- **State Consistency**: All pointer tracking maps properly cleaned up on interruption
- **Cross-Device Compatibility**: Solution works across desktop and mobile touch interactions
- **Memory Management**: Dispose method correctly removes all 5 event listeners

> [!IMPORTANT]
> This PR addresses a critical UX issue where interactive elements become unresponsive after touch interactions on real devices.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Click events now include pointerId for improved multi-pointer context.
  - Enhanced touch handling: pointercancel and pointerleave support for reliable hover cleanup.

- Bug Fixes
  - Prevents stuck hover states and leaks when pointers are canceled or leave on real devices.

- Tests
  - Updated dispose tests to expect removal of five pointer listeners.
  - Added suites validating per-pointer cancel/leave cleanup and out-event emission.

- Documentation
  - Clarified multi-touch “Current State” notes around touch fixes.

- Refactor
  - Minor readability improvement in state update logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->