### PR TITLE
fix(ButtonInteractionHandler): preserve hover state when enabling

### DIFF
--- a/src/interactionHandler/ButtonInteractionHandler.ts
+++ b/src/interactionHandler/ButtonInteractionHandler.ts
@@ -702,9 +702,14 @@ export class ButtonInteractionHandler<Value> extends EventEmitter<
    *
    * @description
    * Changes the enabled state of the interactive object and immediately updates
-   * the interaction state and material. When enabled, the state becomes "normal";
-   * when disabled, the state becomes "disable". All pointer states are cleared
-   * when disabling to prevent stale multitouch interactions.
+   * the interaction state and material. When disabled, all pointer states are cleared
+   * to prevent stale multitouch interactions. When enabled, only press states are
+   * cleared while hover states are preserved to maintain visual feedback.
+   *
+   * @motivation Press state clearing on enable prevents unintended click events when
+   * a button is programmatically enabled while a pointer was previously pressed down.
+   * Hover state preservation maintains proper visual feedback for pointers that are
+   * still over the object when it becomes enabled.
    *
    * @example
    * ```typescript
@@ -724,7 +729,8 @@ export class ButtonInteractionHandler<Value> extends EventEmitter<
       this.updateState("disable");
       return;
     }
-    // On enabling, immediately reflect any existing pointer conditions
+    // On enabling, clear press states but preserve hover states for UX continuity
+    this.pressPointerIds.clear();
     this.updateState(this.calculateCurrentState());
   }
 


### PR DESCRIPTION
## Summary
Improves `switchEnable` method behavior to prevent unintended clicks while maintaining visual feedback continuity.

## Motivation
Resolves UX issue where programmatically enabling a button while a pointer was previously pressed down could trigger unwanted click events. This commonly occurs when UI state changes disable/enable buttons based on user actions or system state.

## Out of Scope
- **Visual state management** - No changes to material transitions or state calculation logic
- **Multi-touch behavior** - Existing multi-touch click suppression remains unchanged
- **Event emission patterns** - No modifications to existing event firing sequences
- **Legacy compatibility** - All existing APIs and behaviors preserved

## Scope
### Target
- `switchEnable` method pointer state management logic
- JSDoc documentation with `@motivation` design rationale
- Comprehensive test coverage for new behavior

### Dependencies
- Existing `onMouseOverOutHandler` hover tracking (leverages unconditional tracking)
- Current `calculateCurrentState` priority logic (disabled → pressed → hovering → normal)
- Multi-touch infrastructure (`pressPointerIds`, `hoverPointerIds` Sets)

### Boundaries
- Changes limited to `switchEnable` method implementation
- No modifications to individual event handlers (`onMouseDownHandler`, etc.)
- Test additions use existing `handleEvent` helper for proper encapsulation
- Documentation updates focus on behavioral contracts, not implementation details

## Review Guidance
### Focus Areas
- UX improvement verification in test cases (lines 762-800)
- Hover state preservation logic correctness (lines 732-733)
- JSDoc `@motivation` clarity for future maintenance decisions

🤖 Generated with [Claude Code](https://claude.ai/code)