### PR TITLE
chore(deps): add 5-day cooldown to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,14 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     ignore:
       - dependency-name: "@vitest/browser"


### PR DESCRIPTION
## Summary
Configure dependabot with 5-day cooldown period to mitigate supply chain attack damage in npm ecosystem.

## Motivation
Reduce exposure window to supply chain attacks by implementing cooldown periods between dependency updates. This provides time buffer for security community to identify and report malicious packages before automatic integration.

#### Security Benefits
- Reduces automatic adoption of compromised package versions
- Provides community validation window for new releases
- Limits blast radius of supply chain attacks through delayed updates
- Maintains security patching capability while reducing attack surface

## Out of Scope
- **Dependency ignore rules** - Existing `@vitest/browser` ignore rule unchanged
- **Update intervals** - Daily schedule maintained for both ecosystems
- **Package ecosystems** - No new ecosystems added, only github-actions and npm modified
- **Manual security reviews** - Cooldown does not replace security audit processes

## Scope
### Target
- GitHub Actions dependabot configuration with 5-day cooldown
- NPM dependabot configuration with 5-day cooldown
- Maintains existing daily interval schedule for vulnerability detection

### Dependencies
- Existing dependabot.yml structure preserved
- Compatible with current GitHub dependabot service
- Works alongside existing security scanning tools

### Boundaries
- Changes limited to cooldown configuration only
- No modifications to ignore rules or scheduling intervals
- No impact on critical security patch deployment (manual override available)

🤖 Generated with [Claude Code](https://claude.ai/code)