### PR TITLE
ci: remove Node.js v18 from CI matrix due to EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
Remove Node.js v18 from CI testing matrix in preparation for its end-of-life on April 30, 2025.

## Motivation
Node.js v18 reaches end-of-life on April 30, 2025. Continuing to test against EOL versions provides no value and wastes CI resources. Updated CI matrix to focus on supported LTS versions only.

## Out of Scope
- **Package.json engines field** - No explicit Node.js version constraints defined, maintaining flexibility
- **Other workflow files** - Already using Node.js 20.x explicitly, no changes needed
- **Documentation updates** - No Node.js v18 specific references found in project docs
- **Dependency updates** - Package compatibility ranges remain unchanged

## Scope
### Target
- CI workflow matrix configuration in `.github/workflows/ci.yml`
- Node.js version array updated from `[18.x, 20.x, 22.x]` to `[20.x, 22.x]`

### Dependencies
- Existing workflow structure unchanged
- All other GitHub Actions workflows continue using Node.js 20.x
- No impact on local development environment requirements

### Boundaries
- Changes limited to CI testing matrix only
- No modifications to package dependencies or runtime requirements
- No changes to build or deployment processes

## Review Guidance
### Focus Areas
- Verify CI matrix configuration syntax correctness
- Confirm no breaking changes to existing workflows
- Validate actionlint passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to run on Node.js 20 and 22 only; Node.js 18 is no longer covered.
  * This aligns automated testing with current Node.js versions and keeps the pipeline up to date.
  * No changes to app features or behavior.
  * If you rely on Node.js 18, consider upgrading to ensure your environment matches our tested configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->