### PR TITLE
revert: rollback v0.20.0 release due to publish failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masatomakino/threejs-interactive-object",
-  "version": "0.20.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@masatomakino/threejs-interactive-object",
-      "version": "0.20.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@masatomakino/threejs-interactive-object",
-  "version": "0.20.0",
+  "version": "0.19.1",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
Reverts v0.20.0 release changes due to npm publish failure, restoring version to 0.19.1.

## Motivation
The v0.20.0 release encountered publish failures that require investigation. Rolling back to maintain stable main branch state while troubleshooting the publish process.

## Out of Scope
- **Root cause analysis** - Publish failure investigation will be handled separately
- **Re-release planning** - v0.20.0 features will be re-released after fixing publish issues
- **Build system changes** - No modifications to CI/CD pipeline in this rollback

## Scope
### Target
- Revert merge commit 782eda5a (Merge pull request #603 from MasatoMakino/version/v0.20.0)
- Restore package.json version from 0.20.0 to 0.19.1
- Restore package-lock.json to pre-v0.20.0 state

### Dependencies
- Local git tag v0.20.0 already removed
- No remote git tag was created due to publish failure
- npm registry unaffected (package was not published)

### Boundaries
- Only reverts version-related changes from v0.20.0 release
- All feature implementations from v0.20.0 development remain available in git history
- No impact on previous published versions (up to 0.19.1)

🤖 Generated with [Claude Code](https://claude.ai/code)