### PR TITLE
fix: correct npm publish workflow trigger event

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,7 +1,8 @@
 name: Publish to NPM
 on:
   release:
-    types: [created]
+    types: [published]
+    
 jobs:
   npm-publish:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
Fixes npm publish workflow trigger from `created` to `published` to ensure publishing only occurs after release notes are completed.

## Motivation
The v0.20.0 release failed to publish because the workflow triggered on `release.created` event, which occurs when a release is first created (potentially in draft state), rather than when the release is actually published with completed release notes.

## Out of Scope
- **Workflow job configuration** - Build and publish steps remain unchanged
- **Release process changes** - No modifications to version bump or release creation workflow
- **Package.json scripts** - No changes to npm scripts or build process

## Scope
### Target
- GitHub Actions workflow trigger configuration in `.github/workflows/npm_publish.yml`
- Change `types: [created]` to `types: [published]` for release event

### Dependencies
- Existing release workflow that creates GitHub releases
- NPM_PUBLISH_TOKEN secret configuration (unchanged)
- Release notes completion process

### Boundaries
- Only modifies trigger event specification
- No changes to build or publish logic
- Maintains existing workflow structure and permissions

## Review Guidance
### Focus Areas
- Trigger event specification correctness
- Alignment with intended release workflow (release notes completion → publish)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release automation to publish packages when a release is officially published rather than when it is first created. This improves timing and consistency of npm availability, reducing premature publishes and aligning with finalized releases. A minor formatting adjustment was also made. No user-facing changes; application features and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->